### PR TITLE
Remove hardcoded paths in flock behavior

### DIFF
--- a/lib/blender/lock/flock.rb
+++ b/lib/blender/lock/flock.rb
@@ -22,7 +22,7 @@ module Blender
   module Lock
     class Flock
       def initialize(name, options)
-        @path = options['path'] || File.join(Dir::tmpdir, name)
+        @path = options['path'] || File.join('/tmp', name)
         @timeout = options[:timeout] || 0
         @job_name = name
       end

--- a/lib/blender/lock/flock.rb
+++ b/lib/blender/lock/flock.rb
@@ -22,7 +22,7 @@ module Blender
   module Lock
     class Flock
       def initialize(name, options)
-        @path = options['path'] || File.join('/tmp', name)
+        @path = options['path'] || File.join(Dir::tmpdir, name)
         @timeout = options[:timeout] || 0
         @job_name = name
       end
@@ -44,6 +44,7 @@ module Blender
       def release
         @lock_fd.flock(File::LOCK_UN)
         @lock_fd.close
+        File.delete(@path) if File.exists?(@path)
       end
 
       def with_lock

--- a/spec/blender/lock_spec.rb
+++ b/spec/blender/lock_spec.rb
@@ -5,7 +5,7 @@ describe Blender::Lock do
     it 'should not allow two blender run with same lockfile to run at the same time' do
       pid1 = fork do
         Blender.blend('test-1') do |sched|
-          sched.lock_options('flock', path: '/var/lock/test-1')
+          sched.lock_options('flock')
           sched.members(['localhost'])
           sched.ruby_task('date') do
             execute do
@@ -19,7 +19,7 @@ describe Blender::Lock do
       pid2 = fork do
         STDERR.reopen(File::NULL)
         Blender.blend('test-1') do |sched|
-          sched.lock_options('flock', path: '/var/lock/test-1')
+          sched.lock_options('flock')
           sched.members(['localhost'])
           sched.ruby_task('date') do
             execute do
@@ -38,7 +38,7 @@ describe Blender::Lock do
     it 'should allow two blender run with different lock file to run at the same time' do
       pid1 = fork do
         Blender.blend('test-1') do |sched|
-          sched.lock_options('flock', path: '/var/lock/test-1')
+          sched.lock_options('flock')
           sched.members(['localhost'])
           sched.ruby_task('date') do
             execute do
@@ -51,7 +51,7 @@ describe Blender::Lock do
 
       pid2 = fork do
         Blender.blend('test-2') do |sched|
-          sched.lock_options('flock', path: '/var/lock/test-2')
+          sched.lock_options('flock')
           sched.members(['localhost'])
           sched.ruby_task('date') do
             execute do
@@ -69,7 +69,7 @@ describe Blender::Lock do
     it 'should raise lock acquisition error when times out' do
       pid1 = fork do
         Blender.blend('test-1') do |sched|
-          sched.lock_options('flock', path: '/var/lock/test-1')
+          sched.lock_options('flock')
           sched.members(['localhost'])
           sched.ruby_task('date') do
             execute do
@@ -84,7 +84,7 @@ describe Blender::Lock do
         STDERR.reopen(File::NULL)
         Blender.blend('test-1') do |sched|
           sched.members(['localhost'])
-          sched.lock_options('flock', timeout: 3, path: '/var/lock/test-1')
+          sched.lock_options('flock', timeout: 3)
           sched.ruby_task('date') do
             execute do
               puts 'This will fail'
@@ -101,7 +101,7 @@ describe Blender::Lock do
     it 'should not raise lock acquisition error when  able to acquire lock within timeout period' do
       pid1 = fork do
         Blender.blend('test-1') do |sched|
-          sched.lock_options('flock', path: '/var/lock/test-1')
+          sched.lock_options('flock')
           sched.members(['localhost'])
           sched.ruby_task('date') do
             execute do
@@ -116,7 +116,7 @@ describe Blender::Lock do
         STDERR.reopen(File::NULL)
         Blender.blend('test-1') do |sched|
           sched.members(['localhost'])
-          sched.lock_options('flock', timeout:10, path: '/var/lock/test-1')
+          sched.lock_options('flock', timeout: 10)
           sched.ruby_task('date') do
             execute do
               puts 'This will fail'


### PR DESCRIPTION
Since I'm running/testing this on an OS that doesn't have /var/lock, I'd
like to have all the tests actually pass.  There's still a flapper
somewhere in the flock code where sometimes the tests pass and sometimes
they don't, but this at least cleans up the pathing & makes it more
platform agnostic.