### PR TITLE
(feat)allow disabling doc event handler

### DIFF
--- a/lib/blender/scheduler.rb
+++ b/lib/blender/scheduler.rb
@@ -38,12 +38,14 @@ module Blender
     attr_reader :events, :tasks
     attr_reader :lock_properties
 
-    def initialize(name, tasks = [], metadata = {})
+    def initialize(name, tasks = [], options = {})
       @name = name
       @tasks = tasks
-      @metadata = default_metadata.merge(metadata)
       @events = Blender::EventDispatcher.new
-      events.register(Blender::Handlers::Doc.new)
+      unless options.delete(:no_doc)
+        events.register(Blender::Handlers::Doc.new)
+      end
+      @metadata = default_metadata.merge(options)
       @scheduling_strategy = nil
       @lock_properties = {driver: nil, driver_options: {}}
     end

--- a/spec/blender/scheduler_spec.rb
+++ b/spec/blender/scheduler_spec.rb
@@ -4,6 +4,14 @@ describe Blender::Scheduler do
   let(:scheduler) do
     described_class.new('test')
   end
+  describe '#no_doc' do
+    it 'should not use document handler if no_doc option is passed' do
+      expect(Blender::Handlers::Doc).to_not receive(:new)
+      task = Blender::Task::Ruby.new('test')
+      sched = described_class.new('no_doc', [] , no_doc: true)
+      sched.run
+    end
+  end
   describe '#DSL' do
     subject(:task){scheduler.tasks.first}
     it '#ask' do


### PR DESCRIPTION
while calling blender from arbitrary library, its often desired to disable the document handler which prints job details.