### PR TITLE
Add Net::SCP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,18 @@ can execute `ssh_task`s. Blender core ships with following tasks and drivers:
   end
   ```
 
+  - **scp_task**: download or upload files using scp
+
+  ```ruby
+  members ['host1', 'host2', 'host3']
+  scp_upload '/foo/bar' do
+    from '/path/to/remote/file'
+  end
+  scp_download '/foo/bar' do
+    to '/local/path'
+  end
+  ```
+
 As mentioned earlier tasks are executed using drivers. Tasks can declare their preferred driver or
 Blender will assign a driver to them automatically. Blender will reuse the global driver if its
 compatible, else it will create one. By default the ```global_driver``` is a ```shell_out``` driver.
@@ -286,7 +298,7 @@ Following are some examples:
   - **chef**: discover hosts using Chef search
 
   ```ruby
-  require 'blender/dscoveries/chef'
+  require 'blender/discoveries/chef'
 
   ruby_task 'print host name' do
     execute do |host|

--- a/blender.gemspec
+++ b/blender.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'mixlib-shellout'
   spec.add_dependency 'mixlib-log'
   spec.add_dependency 'net-ssh'
+  spec.add_dependency 'net-scp'
   spec.add_dependency 'rufus-scheduler'
 
   spec.add_development_dependency 'bundler'

--- a/lib/blender/drivers/scp.rb
+++ b/lib/blender/drivers/scp.rb
@@ -45,6 +45,24 @@ module Blender
           session.loop
         end
       end
+
+      def run_command(command, session)
+        begin
+          case command.direction
+          when :upload
+            session.scp.upload!(command.source, command.target)
+            ExecOutput.new(0, '', '')
+          when :download
+            session.scp.download!(command.source, command.target)
+            ExecOutput.new(0, '', '')
+          else
+            ExecOutput.new(-1, '' , "Invalid direction. Can be either :upload or :download. Found:'#{command.direction}'")
+          end
+        rescue StandardError => e
+          ExecOutput.new(-1, stdout, e.message + e.backtrace.join("\n"))
+        end
+      end
+
       private
 
       def create_session(host)
@@ -54,20 +72,10 @@ module Blender
     end
 
     class ScpUpload < Blender::Driver::Scp
-      def run_command(command, session)
-        begin
-          session.scp.upload!(command.source, command.target)
-          ExecOutput.new(0, '', '')
-        rescue StandardError => e
-          ExecOutput.new(-1, stdout, e.message + e.backtrace.join("\n"))
-        end
-      end
     end
     class ScpDownload < Blender::Driver::Scp
       def run_command(command, session)
         begin
-          session.scp.download!(command.source, command.target)
-          ExecOutput.new(0, '', '')
         rescue StandardError => e
           ExecOutput.new(-1, stdout, e.message + e.backtrace.join("\n"))
         end

--- a/lib/blender/drivers/scp.rb
+++ b/lib/blender/drivers/scp.rb
@@ -1,0 +1,77 @@
+#
+# Author:: Ranjib Dey (<ranjib@pagerduty.com>)
+# Copyright:: Copyright (c) 2015 PagerDuty, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'net/scp'
+require 'net/ssh'
+require 'blender/exceptions'
+require 'blender/drivers/base'
+
+module Blender
+  module Driver
+    class Scp < Base
+      attr_reader :user
+
+      def initialize(config = {})
+        cfg = config.dup
+        @user = cfg.delete(:user) || ENV['USER']
+        super(cfg)
+      end
+
+      def execute(tasks, hosts)
+        Log.debug("SCP execution tasks [#{Array(tasks).size}]")
+        Log.debug("SCP on hosts [#{hosts.join(",")}]")
+        Array(hosts).each do |host|
+          session = create_session(host)
+          Array(tasks).each do |task|
+            cmd = run_command(task.command, session)
+            if cmd.exitstatus != 0 and !task.metadata[:ignore_failure]
+              raise ExecutionFailed, cmd.stderr
+            end
+          end
+          session.loop
+        end
+      end
+      private
+
+      def create_session(host)
+        Log.debug("Invoking ssh: #{user}@#{host}")
+        Net::SSH.start(host, user, config)
+      end
+    end
+
+    class ScpUpload < Blender::Driver::Scp
+      def run_command(command, session)
+        begin
+          session.scp.upload!(command.source, command.target)
+          ExecOutput.new(0, '', '')
+        rescue StandardError => e
+          ExecOutput.new(-1, stdout, e.message + e.backtrace.join("\n"))
+        end
+      end
+    end
+    class ScpDownload < Blender::Driver::Scp
+      def run_command(command, session)
+        begin
+          session.scp.download!(command.source, command.target)
+          ExecOutput.new(0, '', '')
+        rescue StandardError => e
+          ExecOutput.new(-1, stdout, e.message + e.backtrace.join("\n"))
+        end
+      end
+    end
+  end
+end

--- a/lib/blender/scheduler/dsl.rb
+++ b/lib/blender/scheduler/dsl.rb
@@ -120,15 +120,17 @@ module Blender
     end
 
     def scp_upload(name, &block)
-      task = build_task(name, :scp_upload)
+      task = build_task(name, :scp)
       task.instance_eval(&block) if block_given?
-      append_task(:scp_upload, task)
+      task.direction = :upload
+      append_task(:scp, task)
     end
 
     def scp_download(name, &block)
-      task = build_task(name, :scp_download)
+      task = build_task(name, :scp)
       task.instance_eval(&block) if block_given?
-      append_task(:scp_download, task)
+      task.direction = :download
+      append_task(:scp, task)
     end
 
     def strategy(strategy)

--- a/lib/blender/scheduler/dsl.rb
+++ b/lib/blender/scheduler/dsl.rb
@@ -21,12 +21,15 @@ require 'blender/tasks/base'
 require 'blender/tasks/ruby'
 require 'blender/tasks/ssh'
 require 'blender/tasks/shell_out'
+require 'blender/tasks/scp'
 require 'highline'
 require 'blender/utils/refinements'
+require 'blender/drivers/ssh'
 require 'blender/drivers/ssh'
 require 'blender/drivers/ssh_multi'
 require 'blender/drivers/shellout'
 require 'blender/drivers/ruby'
+require 'blender/drivers/scp'
 require 'blender/discovery'
 require 'blender/handlers/base'
 require 'blender/lock/flock'
@@ -114,6 +117,18 @@ module Blender
       task = build_task(name, :ssh)
       task.instance_eval(&block) if block_given?
       append_task(:ssh, task)
+    end
+
+    def scp_upload(name, &block)
+      task = build_task(name, :scp_upload)
+      task.instance_eval(&block) if block_given?
+      append_task(:scp_upload, task)
+    end
+
+    def scp_download(name, &block)
+      task = build_task(name, :scp_download)
+      task.instance_eval(&block) if block_given?
+      append_task(:scp_download, task)
     end
 
     def strategy(strategy)

--- a/lib/blender/tasks/base.rb
+++ b/lib/blender/tasks/base.rb
@@ -21,7 +21,6 @@ module Blender
     class Base
       include Blender::Discovery
 
-      attr_reader :guards
       attr_reader :metadata
       attr_reader :name
       attr_reader :hosts

--- a/lib/blender/tasks/scp.rb
+++ b/lib/blender/tasks/scp.rb
@@ -16,25 +16,23 @@
 # limitations under the License.
 
 require 'blender/tasks/ssh'
+require 'forwardable'
 
 module Blender
   module Task
     class Scp < Blender::Task::Base
+      extend Forwardable
+      def_delegators :@command, :direction, :direction=
       def initialize(name, metadata = {})
         super
-        @command = Struct.new(:source, :target).new
+        @command = Struct.new(:direction, :source, :target).new
         @command.target = name
         @command.source = name
+        @direction = :upload
       end
-    end
-
-    class ScpUpload < Blender::Task::Scp
       def from(source)
         @command.source = source
       end
-    end
-
-    class ScpDownload < Blender::Task::Scp
       def to(target)
         @command.target = target
       end

--- a/lib/blender/tasks/scp.rb
+++ b/lib/blender/tasks/scp.rb
@@ -1,0 +1,43 @@
+#
+# Author:: Ranjib Dey (<ranjib@pagerduty.com>)
+# Copyright:: Copyright (c) 2014 PagerDuty, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'blender/tasks/ssh'
+
+module Blender
+  module Task
+    class Scp < Blender::Task::Base
+      def initialize(name, metadata = {})
+        super
+        @command = Struct.new(:source, :target).new
+        @command.target = name
+        @command.source = name
+      end
+    end
+
+    class ScpUpload < Blender::Task::Scp
+      def from(source)
+        @command.source = source
+      end
+    end
+
+    class ScpDownload < Blender::Task::Scp
+      def to(target)
+        @command.target = target
+      end
+    end
+  end
+end

--- a/spec/blender/dsl_spec.rb
+++ b/spec/blender/dsl_spec.rb
@@ -16,4 +16,33 @@ describe '#dsl' do
     allow_any_instance_of(Blender::Driver::Ssh).to receive(:execute)
     scheduler.run
   end
+
+  context '#scp' do
+    it '#upload' do
+      session = double('Net::SSH::Session', loop: true)
+      scp = double('Net::SSH::Scp')
+      expect(Net::SSH).to receive(:start).with('host1', ENV['USER'], {}).and_return(session)
+      expect(session).to receive(:scp).and_return(scp)
+      expect(scp).to receive(:upload!).with('/local/path', '/remote/path')
+      Blender.blend('test') do |sched|
+        sched.members(['host1'])
+        sched.scp_upload '/remote/path' do
+          from '/local/path'
+        end
+      end
+    end
+    it '#download' do
+      session = double('Net::SSH::Session', loop: true)
+      scp = double('Net::SSH::Scp')
+      expect(Net::SSH).to receive(:start).with('host1', ENV['USER'], {}).and_return(session)
+      expect(session).to receive(:scp).and_return(scp)
+      expect(scp).to receive(:download!).with('/remote/path', '/local/path')
+      Blender.blend('test') do |sched|
+        sched.members(['host1'])
+        sched.scp_download '/remote/path' do
+          to '/local/path'
+        end
+      end
+    end
+  end
 end

--- a/spec/blender/dsl_spec.rb
+++ b/spec/blender/dsl_spec.rb
@@ -21,10 +21,11 @@ describe '#dsl' do
     it '#upload' do
       session = double('Net::SSH::Session', loop: true)
       scp = double('Net::SSH::Scp')
-      expect(Net::SSH).to receive(:start).with('host1', ENV['USER'], {}).and_return(session)
+      expect(Net::SSH).to receive(:start).with('host1', 'x', password: 'y').and_return(session)
       expect(session).to receive(:scp).and_return(scp)
       expect(scp).to receive(:upload!).with('/local/path', '/remote/path')
       Blender.blend('test') do |sched|
+        sched.config(:scp, user: 'x', password: 'y')
         sched.members(['host1'])
         sched.scp_upload '/remote/path' do
           from '/local/path'
@@ -34,11 +35,12 @@ describe '#dsl' do
     it '#download' do
       session = double('Net::SSH::Session', loop: true)
       scp = double('Net::SSH::Scp')
-      expect(Net::SSH).to receive(:start).with('host1', ENV['USER'], {}).and_return(session)
+      expect(Net::SSH).to receive(:start).with('host1', 'x', password: 'y').and_return(session)
       expect(session).to receive(:scp).and_return(scp)
       expect(scp).to receive(:download!).with('/remote/path', '/local/path')
       Blender.blend('test') do |sched|
         sched.members(['host1'])
+        sched.config(:scp, user: 'x', password: 'y')
         sched.scp_download '/remote/path' do
           to '/local/path'
         end


### PR DESCRIPTION
This introduces two additional tasks for Blender. `scp_download` and `scp_upload`
```ruby
scp_upload '/path/to/remote/file' do
  from '/path/to/local/file'
end

scp_download '/path/to/remote/file do
  to '/path/to/local/file'
end
```