### PR TITLE
(feat) Allow nesting

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,18 @@ can execute `ssh_task`s. Blender core ships with following tasks and drivers:
   end
   ```
 
+  - **blend_task**: invoke a blender script as a task (nesting)
+
+  ```ruby
+  members ['host1', 'host2', 'host3']
+  blend_task 'test-task' do
+    file '/path/to/remote/file'
+    concurrency 10
+    strategy :per_host
+  end
+  ```
+
+
 As mentioned earlier tasks are executed using drivers. Tasks can declare their preferred driver or
 Blender will assign a driver to them automatically. Blender will reuse the global driver if its
 compatible, else it will create one. By default the ```global_driver``` is a ```shell_out``` driver.

--- a/lib/blender/drivers/blend.rb
+++ b/lib/blender/drivers/blend.rb
@@ -1,0 +1,60 @@
+#
+# Author:: Ranjib Dey (<ranjib@pagerduty.com>)
+# Copyright:: Copyright (c) 2015 PagerDuty, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'blender/drivers/base'
+
+module Blender
+  module Driver
+    class Blend < Base
+      def execute(tasks, hosts)
+        tasks.each do |task|
+          cmd = run_command(task.command, hosts)
+          if cmd.exitstatus != 0 and !task.metadata[:ignore_failure]
+            raise ExecutionFailed, cmd.stderr
+          end
+        end
+      end
+
+      def run_command(command, hosts)
+        exit_status = 0
+        err = ''
+        current_stdout = STDOUT.clone
+        current_stderr = STDERR.clone
+        begin
+          STDOUT.reopen(stdout)
+          STDERR.reopen(stderr)
+          Blender.blend(command.file) do |sched|
+            sched.strategy(command.strategy)
+            sched.members(hosts)
+            sched.concurrency(command.concurrency)
+            command.config_store.keys.each do |key|
+              sched.config(key, command.config_store[key])
+            end
+            sched.instance_eval(File.read(command.file))
+          end
+        rescue StandardError => e
+          err = e.message + "\nBacktrace:" + e.backtrace.join("\n")
+          exit_status = -1
+        ensure
+          STDOUT.reopen(current_stdout)
+          STDERR.reopen(current_stderr)
+        end
+        ExecOutput.new(exit_status, '', err)
+      end
+    end
+  end
+end

--- a/lib/blender/scheduler/dsl.rb
+++ b/lib/blender/scheduler/dsl.rb
@@ -22,6 +22,7 @@ require 'blender/tasks/ruby'
 require 'blender/tasks/ssh'
 require 'blender/tasks/shell_out'
 require 'blender/tasks/scp'
+require 'blender/tasks/blend'
 require 'highline'
 require 'blender/utils/refinements'
 require 'blender/drivers/ssh'
@@ -30,6 +31,7 @@ require 'blender/drivers/ssh_multi'
 require 'blender/drivers/shellout'
 require 'blender/drivers/ruby'
 require 'blender/drivers/scp'
+require 'blender/drivers/blend'
 require 'blender/discovery'
 require 'blender/handlers/base'
 require 'blender/lock/flock'
@@ -134,6 +136,15 @@ module Blender
       task.instance_eval(&block) if block_given?
       task.direction = :download
       append_task(:scp, task, blender_config(:ssh))
+    end
+
+    def blend_task(name, &block)
+      task = build_task(name, :blend)
+      task.instance_eval(&block) if block_given?
+      task.pass_configs.each do |key|
+        task.config_store[key] = blender_config(key).dup
+      end
+      append_task(:blend, task)
     end
 
     def strategy(strategy)

--- a/lib/blender/scheduler/dsl.rb
+++ b/lib/blender/scheduler/dsl.rb
@@ -141,8 +141,8 @@ module Blender
     def blend_task(name, &block)
       task = build_task(name, :blend)
       task.instance_eval(&block) if block_given?
-      task.pass_configs.each do |key|
-        task.config_store[key] = blender_config(key).dup
+      task.command.pass_configs.each do |key|
+        task.command.config_store[key] = blender_config(key).dup
       end
       append_task(:blend, task)
     end

--- a/lib/blender/tasks/blend.rb
+++ b/lib/blender/tasks/blend.rb
@@ -1,0 +1,62 @@
+#
+# Author:: Ranjib Dey (<ranjib@pagerduty.com>)
+# Copyright:: Copyright (c) 2014 PagerDuty, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'blender/tasks/base'
+
+module Blender
+  module Task
+    class Blend < Base
+      attr_reader :blender_strategy
+
+      def initialize(name, metadata = {})
+        super
+        @command = Struct.new(
+          :file,
+          :strategy,
+          :pass_configs,
+          :config_store,
+          :concurrency).new
+        @command.strategy = :default
+        @command.concurrency = 1
+        @command.pass_configs = []
+        @command.config_store = ThreadSafe::Cache.new
+      end
+
+      def strategy(st)
+        @command.strategy = st
+      end
+
+      def execute(f)
+        @command.file = f
+      end
+
+      alias file execute
+
+      def concurrency(n)
+        @command.concurrency = n
+      end
+
+      def pass_configs(*keys)
+        @command.pass_configs = keys
+      end
+
+      def config(key, opts = {})
+        @command.config_store[key] = opts
+      end
+    end
+  end
+end

--- a/lib/blender/tasks/blend.rb
+++ b/lib/blender/tasks/blend.rb
@@ -51,7 +51,7 @@ module Blender
       end
 
       def pass_configs(*keys)
-        @command.pass_configs = keys
+        @command.pass_configs += keys unless keys.empty?
       end
 
       def config(key, opts = {})

--- a/spec/blender/drivers/blend_spec.rb
+++ b/spec/blender/drivers/blend_spec.rb
@@ -1,17 +1,25 @@
 require 'spec_helper'
 
 describe Blender do
-  it 'allows sub-blend' do
-    expect(File).to receive(:read).with('/tmp/fake.rb').and_return('')
+  let(:scp_config) do
+    { user: 'test-user', password: 'test-password' }
+  end
+  let!(:sched) do
+    blender_file = File.expand_path('../../../data/example.rb', __FILE__)
     sched = Blender.blend('sub blend', no_doc: true) do |sched|
-      sched.config(:scp, user: 'test-user', password: 'test-password')
+      sched.config(:scp, scp_config)
       sched.members(['1.2.3.4'])
       sched.blend_task 'foo' do
-        file '/tmp/fake.rb'
+        file blender_file
         strategy :per_task
         pass_configs :scp
         concurrency 3
       end
     end
+  end
+
+  it 'passes apropriate config options from parent blender script' do
+    blend_task = sched.tasks.first
+    expect(blend_task.command.config_store[:scp]).to eq(scp_config)
   end
 end

--- a/spec/blender/drivers/blend_spec.rb
+++ b/spec/blender/drivers/blend_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe Blender do
+  it 'allows sub-blend' do
+    expect(File).to receive(:read).with('/tmp/fake.rb').and_return('')
+    sched = Blender.blend('sub blend', no_doc: true) do |sched|
+      sched.config(:scp, user: 'test-user', password: 'test-password')
+      sched.members(['1.2.3.4'])
+      sched.blend_task 'foo' do
+        file '/tmp/fake.rb'
+        strategy :per_task
+        pass_configs :scp
+        concurrency 3
+      end
+    end
+  end
+end

--- a/spec/blender/tasks/blend_spec.rb
+++ b/spec/blender/tasks/blend_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe Blender::Task::Blend do
+  let(:task) do
+    described_class.new('blend-test')
+  end
+
+  it 'setup task name accordingly' do
+    expect(task.name).to eq('blend-test')
+  end
+
+  it 'setup blender file accordingly' do
+    task.execute '/foo/bar'
+    expect(task.command.file).to eq('/foo/bar')
+  end
+
+  it 'setup strategy for the blender job accordingly' do
+    task.strategy :foo
+    expect(task.command.strategy).to eq(:foo)
+  end
+
+  it 'setup concurrency correctly' do
+    task.concurrency(10)
+    expect(task.command.concurrency).to eq(10)
+  end
+
+  it 'setup explicit config accordingly' do
+    task.config(:foo, bar: 'baz')
+    expect(task.command.config_store[:foo]).to eq(bar: 'baz')
+  end
+
+  it 'has empty config by default' do
+    expect(task.command.config_store).to be_empty
+  end
+
+  it 'specifies the list of configs copied correctly' do
+    task.pass_configs :foo, :bar, :baz
+    expect(task.command.pass_configs).to eq([:foo, :bar, :baz])
+    expect(task.command.config_store).to be_empty
+  end
+end


### PR DESCRIPTION
Allow running full blown blender scripts as a task from other blender jobs.
- Introduce `blend_task` as DSL method to specify sub-blends :-)
- the new task allows specifying strategy, concurrency, script path etc 

```ruby
blend_task 'cassandra_repair' do
  script 'blends/repair.rb'
  strategy :per_host
end
```
By default, driver specific configurations are not passed. User can either specify configurations explicitly, or tell blender to copy a list of driver configurations.

Example of specifying explicit configurations:
```ruby
blend_task 'cassandra_repair' do
  script 'blends/repair.rb'
  config :ssh, user: 'ubuntu', password: 'test'
end
```

To copy over the configurations from current blender script:
```ruby
blend_task 'cassandra_repair' do
  script 'blends/repair.rb'
  pass_configs :ssh
end
```