### PR TITLE
Idea to fix output when executing a command that fails.

### DIFF
--- a/lib/blender/drivers/base.rb
+++ b/lib/blender/drivers/base.rb
@@ -26,8 +26,8 @@ module Blender
 
       def initialize(config = {})
         cfg = config.dup
-        @stdout = cfg.delete(:stdout) || File.open(File::NULL, 'w')
-        @stderr = cfg.delete(:stderr) || File.open(File::NULL, 'w')
+        @stdout = cfg.delete(:stdout) || Tempfile.new('blender-stdout')
+        @stderr = cfg.delete(:stderr) || Tempfile.new('blender-stderr')
         @events = cfg.delete(:events) or fail 'Events needed'
         @config = cfg
       end

--- a/lib/blender/drivers/scp.rb
+++ b/lib/blender/drivers/scp.rb
@@ -59,7 +59,8 @@ module Blender
             ExecOutput.new(-1, '' , "Invalid direction. Can be either :upload or :download. Found:'#{command.direction}'")
           end
         rescue StandardError => e
-          ExecOutput.new(-1, stdout, e.message + e.backtrace.join("\n"))
+          stdout.rewind
+          ExecOutput.new(-1, stdout.read, e.message + e.backtrace.join("\n"))
         end
       end
 
@@ -77,7 +78,8 @@ module Blender
       def run_command(command, session)
         begin
         rescue StandardError => e
-          ExecOutput.new(-1, stdout, e.message + e.backtrace.join("\n"))
+          stdout.rewind
+          ExecOutput.new(-1, stdout.read, e.message + e.backtrace.join("\n"))
         end
       end
     end

--- a/lib/blender/drivers/ssh.rb
+++ b/lib/blender/drivers/ssh.rb
@@ -49,7 +49,9 @@ module Blender
 
       def run_command(command, session)
         exit_status = remote_exec(command, session)
-        ExecOutput.new(exit_status, stdout, stderr)
+        stdout.rewind
+        stderr.rewind
+        ExecOutput.new(exit_status, stdout.read, stderr.read)
       end
 
       private


### PR DESCRIPTION
Throwing this out here. This is to fix the output when an ssh command exits with non-zero status. The output currently is:

```
Blender::ExecutionFailed: #<File:0x00562760b79ca0>
```

With this change, the output would be the content of stderr.

Feedback I would like to get:
* Is using a tempfile instead of /dev/null crazy talk? Do the implications outweigh the benefits?
* How would I test this? Not clear from the code how I would stub the ssh command to return a non-zero exit code, without actually mocking the class under test.
* I would like to also output ~300 characters of standard out as part of `raise ExecutionError, stderr` when a command fails. Is that crazy talk?

If this PR seems reasonable, I will put up a different PR with tests, etc.