### PR TITLE
Separate output from different hosts multi ssh

### DIFF
--- a/lib/blender/drivers/scp.rb
+++ b/lib/blender/drivers/scp.rb
@@ -71,16 +71,5 @@ module Blender
         Net::SSH.start(host, user, config)
       end
     end
-
-    class ScpUpload < Blender::Driver::Scp
-    end
-    class ScpDownload < Blender::Driver::Scp
-      def run_command(command, session)
-        begin
-        rescue StandardError => e
-          ExecOutput.new(-1, stdout, e.message + e.backtrace.join("\n"))
-        end
-      end
-    end
   end
 end

--- a/lib/blender/drivers/scp.rb
+++ b/lib/blender/drivers/scp.rb
@@ -59,7 +59,8 @@ module Blender
             ExecOutput.new(-1, '' , "Invalid direction. Can be either :upload or :download. Found:'#{command.direction}'")
           end
         rescue StandardError => e
-          ExecOutput.new(-1, stdout, e.message + e.backtrace.join("\n"))
+          # our implementation doesn't generate stdout, so return '' as stdout
+          ExecOutput.new(-1, '', e.message + e.backtrace.join("\n"))
         end
       end
 

--- a/lib/blender/drivers/ssh.rb
+++ b/lib/blender/drivers/ssh.rb
@@ -40,7 +40,7 @@ module Blender
           Array(tasks).each do |task|
             cmd = run_command(task.command, session)
             if cmd.exitstatus != 0 and !task.metadata[:ignore_failure]
-              raise ExecutionFailed, cmd.stderr
+              raise ExecutionFailed, { stderr: cmd.stderr, stdout: cmd.stdout }.to_json
             end
           end
           session.loop
@@ -48,8 +48,7 @@ module Blender
       end
 
       def run_command(command, session)
-        exit_status = remote_exec(command, session)
-        ExecOutput.new(exit_status, stdout, stderr)
+        aggregate_results(remote_exec(command, session))
       end
 
       private
@@ -57,6 +56,22 @@ module Blender
       def create_session(host)
         Log.debug("Invoking ssh: #{user}@#{host}")
         Net::SSH.start(host, user, config)
+      end
+
+      def aggregate_results(command_results)
+        status = command_results
+          .map { |h, r| r.exitstatus }
+          .reject { |x| x.zero? }
+          .first || 0
+        stdout = join_output(command_results, :stdout)
+        stderr = join_output(command_results, :stderr)
+        ExecOutput.new(status, stdout, stderr)
+      end
+
+      def join_output(results, stream_name)
+        output = {}
+        results.each { |host, result| output[host] = result.send(stream_name).read }
+        output
       end
     end
   end

--- a/lib/blender/drivers/ssh.rb
+++ b/lib/blender/drivers/ssh.rb
@@ -59,10 +59,7 @@ module Blender
       end
 
       def aggregate_results(command_results)
-        status = command_results
-          .map { |h, r| r.exitstatus }
-          .reject { |x| x.zero? }
-          .first || 0
+        status = command_results.all? { |k,v| v.exitstatus.zero? } ? 0 : 1
         stdout = join_output(command_results, :stdout)
         stderr = join_output(command_results, :stderr)
         ExecOutput.new(status, stdout, stderr)

--- a/lib/blender/drivers/ssh_exec.rb
+++ b/lib/blender/drivers/ssh_exec.rb
@@ -22,41 +22,41 @@ module Blender::Driver::SSHExec
     password = config[:password]
     command = fixup_sudo(command)
 
-    command_results = ThreadSafe::Hash.new do |command_results, host|
-      command_results[host] = Blender::Driver::Base::ExecOutput.new(
+    results = ThreadSafe::Hash.new do |results, host|
+      results[host] = Blender::Driver::Base::ExecOutput.new(
         0,
         Tempfile.new('blender-stdout'),
         Tempfile.new('blender-stderr')
       )
     end
     channel = session.open_channel do |ch|
-      command_result = command_results[ch.connection.host]
+      result = results[ch.connection.host]
       ch.request_pty
       ch.exec(command) do |ch, success|
         unless success
           Blender::Log.debug("Command not found:#{success.inspect}")
-          command_result.exitstatus = -1
+          result.exitstatus = -1
         end
         ch.on_data do |c, data|
-          command_result.stdout << data
+          result.stdout << data
           c.send_data("#{password}\n") if data =~ /^blender sudo password: /
         end
         ch.on_extended_data do |c, type, data|
-          command_result.stderr << data
+          result.stderr << data
         end
         ch.on_request "exit-status" do |ichannel, data|
-          command_result.exitstatus = data.read_long
-          Blender::Log.debug("exit-status data:#{command_result.exitstatus}")
+          result.exitstatus = data.read_long
+          Blender::Log.debug("exit-status data:#{result.exitstatus}")
         end
         ch.on_close do |ch|
-          command_result.stdout.rewind
-          command_result.stderr.rewind
+          result.stdout.rewind
+          result.stderr.rewind
         end
       end
-      Blender::Log.debug("Exit(#{command_result.exitstatus}) Command: '#{command}'")
+      Blender::Log.debug("Exit(#{result.exitstatus}) Command: '#{command}'")
     end
     channel.wait
-    command_results
+    results
   end
 
   def fixup_sudo(command)

--- a/lib/blender/drivers/ssh_multi.rb
+++ b/lib/blender/drivers/ssh_multi.rb
@@ -32,7 +32,7 @@ module Blender
           session = create_session(hosts, task.metadata[:concurrency])
           cmd = run_command(task.command, session)
           if cmd.exitstatus != 0 and !task.metadata[:ignore_failure]
-            raise ExecutionFailed, cmd.stderr
+            raise ExecutionFailed, { stderr: cmd.stderr, stdout: cmd.stdout }.to_json
           end
           session.loop
         end

--- a/lib/blender/scheduler/dsl.rb
+++ b/lib/blender/scheduler/dsl.rb
@@ -90,14 +90,13 @@ module Blender
     end
 
     def append_task(type, task, driver_config = {})
-      Log.debug("Appended task:#{task.name}")
-      klass = Blender::Driver.const_get(camelcase(type.to_s).to_sym)
       if task.driver.nil?
         opts = driver_config.dup
         opts.merge!(blender_config(type)) unless blender_config(type).empty?
         opts.merge!(task.driver_opts)
         task.use_driver(driver(type, opts))
       end
+      Log.debug("Appending task:#{task.name} with driver:#{task.driver.class.name}")
       @tasks << task
     end
 


### PR DESCRIPTION
# summary

This changeset is for the SSH drivers. The results of this change are that when an error is raised during execution, in either ssh-multi or not-multi, instead of a single file descriptor being raised with the error, a json hash containing the standard error/output by host will be raised.

# tests

I did not update the tests because that would have been a nightmare because we use multi-ssh. I do however have a PR incoming for blender-integration which should cover the multi-ssh case.

# concerns

@ranjib suggested allowing the user to change what type of object would receive the standard error / output. This is a really good idea, but I ran out of energy, so I would be happy to pass that work onto someone else :)

One other possible objection to this PR (brought up by @nickpegg in https://github.com/PagerDuty/blender/pull/50) is that I am changing the object type in the `stderr` and `stdout` fields in the object returned by `run_command`. A couple points on that:
- different drivers return strings or file descriptors--it seems like the interface is not unified already, and at least a hash has meaningful output when printed vs a file descriptor
- it seems to me like the main interface for the drivers is via the `execute` method, and not via `run_command`. In fact in another world I might be tempted to make `run_command` protected.

I can however address this if people think it's important, either by making the output returned by run_command a string, or a file descriptor.