### PR TITLE
Use configured stdout & stderr objects for ssh & ssh-multi

### DIFF
--- a/lib/blender/drivers/ssh.rb
+++ b/lib/blender/drivers/ssh.rb
@@ -29,6 +29,8 @@ module Blender
       def initialize(config = {})
         cfg = config.dup
         @user = cfg.delete(:user) || ENV['USER']
+        cfg[:stdout] ||= {}
+        cfg[:stderr] ||= {}
         super(cfg)
       end
 
@@ -60,8 +62,8 @@ module Blender
 
       def aggregate_results(command_results)
         status = command_results.all? { |k,v| v.exitstatus.zero? } ? 0 : 1
-        stdout = join_output(command_results, :stdout)
-        stderr = join_output(command_results, :stderr)
+        @stdout.merge!(join_output(command_results, :stdout))
+        @stderr.merge!(join_output(command_results, :stderr))
         ExecOutput.new(status, stdout, stderr)
       end
 

--- a/lib/blender/drivers/ssh_multi.rb
+++ b/lib/blender/drivers/ssh_multi.rb
@@ -24,7 +24,6 @@ require 'net/ssh/multi'
 module Blender
   module Driver
     class SshMulti < Ssh
-
       def execute(tasks, hosts)
         Log.debug("SSH execution tasks [#{tasks.size}]")
         Log.debug("SSH on hosts [#{hosts.join("\n")}]")


### PR DESCRIPTION
In https://github.com/PagerDuty/blender/pull/53, the output from
multi-ssh got separated by host in a hash. However, that hash never made
it back to the user because whatever the user configured as stdout and
stderr got overwritten with a new hash reference. This will allow the
user to pass in an empty hash for stdout and stderr, and have their
command output populate the input hashes.
